### PR TITLE
Add Windows start script

### DIFF
--- a/horary78-main/README.md
+++ b/horary78-main/README.md
@@ -20,6 +20,24 @@ docker run -p 5000:5000 horary-app
 
 The API will be available on `http://localhost:5000`.
 
+## Local Start Scripts
+
+If you prefer to run the backend directly instead of using Docker, two helper
+scripts are provided. On Unix systems run `start.sh`:
+
+```bash
+./start.sh
+```
+
+Windows users can start the API with `start.bat`:
+
+```bat
+start.bat
+```
+
+Both scripts expect the `PORT` environment variable to be defined and will
+install Python dependencies on first run if they are not already cached.
+
 ## Windows Packaging
 
 If you want to distribute the application through the Microsoft Store you can

--- a/horary78-main/start.bat
+++ b/horary78-main/start.bat
@@ -1,0 +1,17 @@
+@echo off
+rem Render start script for Windows
+set PORT=%PORT%
+
+echo Starting Horary Astrology API on port %PORT%
+
+if not exist "C:\opt\render\project\.venv" (
+    echo Installing dependencies...
+    pip install -r backend\requirements.txt
+)
+
+call gunicorn wsgi:application ^
+    --bind 0.0.0.0:%PORT% ^
+    --workers 1 ^
+    --timeout 120 ^
+    --access-logfile - ^
+    --error-logfile -


### PR DESCRIPTION
## Summary
- add `start.bat` for Windows users mirroring `start.sh`
- document local start scripts in README

## Testing
- `python -m compileall backend`
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68452e3336148324b5e2f4fe6f09a111