### PR TITLE
Add watchdog dependency

### DIFF
--- a/horary78-main/README.md
+++ b/horary78-main/README.md
@@ -9,6 +9,8 @@ For local development, install the Python packages using the requirements file i
 ```bash
 pip install -r backend/requirements.txt
 ```
+The requirements file lists core packages like Flask and now includes
+`watchdog>=3.0.0` for file change monitoring.
 
 ## Build the Image
 

--- a/horary78-main/backend/requirements.txt
+++ b/horary78-main/backend/requirements.txt
@@ -22,6 +22,7 @@ gunicorn==21.2.0
 
 # Development dependencies
 python-dotenv==1.0.0
+watchdog>=3.0.0
 
 # Building executables
 pyinstaller==6.1.0


### PR DESCRIPTION
## Summary
- include watchdog>=3.0.0 in backend requirements
- mention watchdog in Install Dependencies section of README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68453446cd408324847f7c11465fb873